### PR TITLE
Fix open redirect in Basic authentication

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -82,6 +82,8 @@ class auth_plugin_basic extends auth_plugin_base {
 
         global $CFG, $DB, $USER, $SESSION;
 
+        $wantsurl = optional_param('wantsurl', '', PARAM_LOCALURL);
+
         $this->log(__FUNCTION__);
 
         if ( isset($_SERVER['PHP_AUTH_USER']) &&
@@ -118,8 +120,8 @@ class auth_plugin_basic extends auth_plugin_base {
 
                         if (isset($SESSION->wantsurl) && !empty($SESSION->wantsurl)) {
                             $urltogo = $SESSION->wantsurl;
-                        } else if (isset($_GET['wantsurl'])) {
-                            $urltogo = $_GET['wantsurl'];
+                        } else if ($wantsurl !== '') {
+                            $urltogo = $wantsurl;
                         } else {
                             $urltogo = $CFG->wwwroot;
                         }


### PR DESCRIPTION
Fixes #49.

This change prevents an open redirect after successful Basic authentication by validating the wantsurl parameter using PARAM_LOCALURL.

The existing session-based redirect behaviour remains unchanged. If no valid local wantsurl is provided, the existing fallback to the Moodle site is used.