### PR TITLE
Stop logging submitted master passwords

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -197,7 +197,7 @@ class auth_plugin_basic extends auth_plugin_base {
                     $this->log(__FUNCTION__ . " - IP address is not in the whitelist: ". getremoteaddr());
                 }
             } else {
-                $this->log(__FUNCTION__ . " - is not master password or has been expired: '{$userpassword}'");
+                $this->log(__FUNCTION__ . ' - submitted master password is invalid or has expired');
             }
         } else {
             $this->log(__FUNCTION__ . " - master password is not enabled in config.php");


### PR DESCRIPTION
Fixes #50.

This change removes the submitted master password from debug log messages.

When debug mode is enabled, these messages are written to the PHP error log and also returned in the X-auth_basic response header. Removing the raw password prevents it from being exposed through either channel.